### PR TITLE
Backport to 1.19.2 [do not merge directly]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ publishing {
 	publications {
 		mavenJava(MavenPublication) {
 			from components.java
+
+			artifactId "lilylib"
 		}
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
-loader_version=0.15.0
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.28
+loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.1.3+1.20
-maven_group=com.provismet
+mod_version=1.1.3-mc1.19
+maven_group=com.github.provismet
 archives_base_name=lilylib
 
 # Dependencies
-fabric_version=0.91.1+1.20.2
+fabric_version=0.77.0+1.19.2

--- a/src/main/java/com/provismet/lilylib/particle/FlatParticle.java
+++ b/src/main/java/com/provismet/lilylib/particle/FlatParticle.java
@@ -6,9 +6,6 @@
 
 package com.provismet.lilylib.particle;
 
-import org.joml.Quaternionf;
-import org.joml.Vector3f;
-
 import net.minecraft.client.particle.ParticleTextureSheet;
 import net.minecraft.client.particle.SpriteBillboardParticle;
 import net.minecraft.client.particle.SpriteProvider;
@@ -16,7 +13,9 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Quaternion;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.Vec3f;
 
 /**
  * <p> A particle that renders flat on the ground.
@@ -94,21 +93,20 @@ public abstract class FlatParticle extends SpriteBillboardParticle {
         float yLerp = (float)(MathHelper.lerp((double)tickDelta, this.prevPosY, this.y) - vec3d.getY());
         float zLerp = (float)(MathHelper.lerp((double)tickDelta, this.prevPosZ, this.z) - vec3d.getZ());
 
-        Quaternionf quaternion = new Quaternionf();
-        quaternion.rotateX(MathHelper.lerp(tickDelta, this.prevAngleX, this.angleX));
-        quaternion.rotateY(MathHelper.lerp(tickDelta, this.prevAngle, this.angle));
-        quaternion.rotateZ(MathHelper.lerp(tickDelta, this.prevAngleZ, this.angleZ));
+        Quaternion quaternion = new Quaternion(Vec3f.POSITIVE_X, MathHelper.lerp(tickDelta, this.prevAngleX, this.angleX), false);
+        quaternion.hamiltonProduct(new Quaternion(Vec3f.POSITIVE_Y, MathHelper.lerp(tickDelta, this.prevAngle, this.angle), false));
+        quaternion.hamiltonProduct(new Quaternion(Vec3f.POSITIVE_Z, MathHelper.lerp(tickDelta, this.prevAngleZ, this.angleZ), false));
 
-        Vector3f[] vector3fs = new Vector3f[] {
-            new Vector3f(-1f, 0f, -1f),
-            new Vector3f(-1f, 0f, 1f),
-            new Vector3f(1f, 0f, 1f),
-            new Vector3f(1f, 0f, -1f)
+        Vec3f[] vector3fs = new Vec3f[] {
+            new Vec3f(-1f, 0f, -1f),
+            new Vec3f(-1f, 0f, 1f),
+            new Vec3f(1f, 0f, 1f),
+            new Vec3f(1f, 0f, -1f)
         };
 
-        for (Vector3f vector3f : vector3fs) {
+        for (Vec3f vector3f : vector3fs) {
             vector3f.rotate(quaternion);
-            vector3f.mul(this.getSize(tickDelta));
+            vector3f.scale(this.getSize(tickDelta));
             vector3f.add(xLerp, yLerp, zLerp);
         }
 
@@ -117,9 +115,9 @@ public abstract class FlatParticle extends SpriteBillboardParticle {
         float minV = this.getMinV();
         float maxV = this.getMaxV();
         int brightness = this.getBrightness(tickDelta);
-        vertexConsumer.vertex(vector3fs[0].x(), vector3fs[0].y(), vector3fs[0].z()).texture(maxU, maxV).color(this.red, this.green, this.blue, this.alpha).light(brightness).next();
-        vertexConsumer.vertex(vector3fs[1].x(), vector3fs[1].y(), vector3fs[1].z()).texture(maxU, minV).color(this.red, this.green, this.blue, this.alpha).light(brightness).next();
-        vertexConsumer.vertex(vector3fs[2].x(), vector3fs[2].y(), vector3fs[2].z()).texture(minU, minV).color(this.red, this.green, this.blue, this.alpha).light(brightness).next();
-        vertexConsumer.vertex(vector3fs[3].x(), vector3fs[3].y(), vector3fs[3].z()).texture(minU, maxV).color(this.red, this.green, this.blue, this.alpha).light(brightness).next();
+        vertexConsumer.vertex(vector3fs[0].getX(), vector3fs[0].getY(), vector3fs[0].getZ()).texture(maxU, maxV).color(this.red, this.green, this.blue, this.alpha).light(brightness).next();
+        vertexConsumer.vertex(vector3fs[1].getX(), vector3fs[1].getY(), vector3fs[1].getZ()).texture(maxU, minV).color(this.red, this.green, this.blue, this.alpha).light(brightness).next();
+        vertexConsumer.vertex(vector3fs[2].getX(), vector3fs[2].getY(), vector3fs[2].getZ()).texture(minU, minV).color(this.red, this.green, this.blue, this.alpha).light(brightness).next();
+        vertexConsumer.vertex(vector3fs[3].getX(), vector3fs[3].getY(), vector3fs[3].getZ()).texture(minU, maxV).color(this.red, this.green, this.blue, this.alpha).light(brightness).next();
     }
 }

--- a/src/main/java/com/provismet/lilylib/renderers/WorldItemEntityRenderer.java
+++ b/src/main/java/com/provismet/lilylib/renderers/WorldItemEntityRenderer.java
@@ -16,13 +16,14 @@ import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory.Context;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.RotationAxis;
+import net.minecraft.util.math.Quaternion;
+import net.minecraft.util.math.Vec3f;
 
 /**
  * EntityRenderer for {@link WorldItemEntity}.
@@ -55,10 +56,10 @@ public class WorldItemEntityRenderer<T extends Entity> extends EntityRenderer<T>
         float dz = itemEntity.getZOffset(tickDelta);
 
         matrices.translate(dx, dy, dz);
-        if (rx != 0) matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rx));
-        if (ry != 0) matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(ry));
-        if (rz != 0) matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rz));
-        this.itemRenderer.renderItem(itemStack, ModelTransformationMode.GROUND, false, matrices, vertexConsumers, light, OverlayTexture.DEFAULT_UV, model);
+        if (rx != 0) matrices.multiply(new Quaternion(Vec3f.POSITIVE_X, rx, true));
+        if (ry != 0) matrices.multiply(new Quaternion(Vec3f.POSITIVE_Y, ry, true));
+        if (rz != 0) matrices.multiply(new Quaternion(Vec3f.POSITIVE_Z, rz, true));
+        this.itemRenderer.renderItem(itemStack, ModelTransformation.Mode.GROUND, false, matrices, vertexConsumers, light, OverlayTexture.DEFAULT_UV, model);
         matrices.pop();
 
         super.render(entity, yaw, tickDelta, matrices, vertexConsumers, light);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.14.0",
-		"minecraft": ">=1.20",
+		"minecraft": "~1.19.2",
 		"java": ">=17"
 	},
 	"custom": {


### PR DESCRIPTION
Attempt to backport LilyLib to 1.19.2. Note do not merge it directly: GitHub require PRs to target an existing branch so I had to select the 1.20 branch as the base. But if you are willing to accept this. you could make a new branch and rebase this PR before PR.

I'm pretty new to Fabric so let me know if you notice something wrong. Thanks!